### PR TITLE
Add Zustand state management for game sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Persist middleware for automatic localStorage synchronization (`europarty:session`)
 
 ### Changed
-- **Lobby component now reads all session state from Zustand instead of localStorage**
-- **Difficulty selection writes to both Firestore (multiplayer sync) and Zustand (local state)**
 - MultiplayerLobby now writes session data to Zustand when creating/joining rooms
-- Replaced fragile navigation state dependencies with centralized store
+- Session state written to both Zustand and localStorage during migration period
 
 ### Fixed
-- Fixed styled-components warning for boolean `secondary` prop in MultiplayerLobby
-- Multiplayer lobby state now persists reliably across page refreshes
-- Players no longer lose room context when refreshing during lobby
-- Removed unused `_playerId` and `_index` variables
+- Fixed styled-components warning for boolean `secondary` prop by prefixing with `$`
+- Fixed TypeScript linting errors (unused variables, `any` types)
+- Removed unused `_gameCode` state variable from MultiplayerLobby
 
 ### Technical
-- **Completed Issue #1: Zustand now manages full session lifecycle (write + read + persist)**
-- Lobby.tsx migration removes all direct localStorage reads for session data
-- Store uses `europarty:session` localStorage key with version 0
-- No TypeScript `any` types in store implementation
+- MultiplayerLobby writes to Zustand store on room creation and join
+- Backward compatibility maintained with localStorage during migration
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Zustand state management for client-side session persistence
 - Centralized game session store (`useGameSession`) with full TypeScript typing
 - Persist middleware for automatic localStorage synchronization (`europarty:session`)
+- JSDocs documentation to MultiplayerLobby.tsx, Lobby.tsx and Quiz.tsx 
 
 ### Changed
 - MultiplayerLobby now writes session data to Zustand when creating/joining rooms
 - Session state written to both Zustand and localStorage during migration period
+- Removed comments from MultiplayerLobby.tsx, Lobby.tsx and Quiz.tsx
 
 ### Fixed
 - Fixed styled-components warning for boolean `secondary` prop by prefixing with `$`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,218 +1,140 @@
 # Changelog
 
-## [0.1.0] - 2025-05-13
-### Added
-- Added multiplayer quiz mode
+All notable changes to this project will be documented in this file.
 
-### Fixed
-- Fixed hydration issue in HeroBanner
-- Fixed Mid-Quiz Scoreboard not updating scores for host in real-time
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-### Changed
-- Optimized API calls using caching
+---
 
 ## [Unreleased]
+
 ### Added
-- Added host observer mode allowing quiz hosts to monitor players without participating (13 May 2025)
-- Added dedicated HostObserverView component for better separation of concerns (14 May 2025)
-- Added player readiness tracking at mid-quiz scoreboard to ensure all participants are ready before continuing (14 May 2025)
+- Zustand state management for client-side session persistence
+- Centralized game session store (`useGameSession`) with full TypeScript typing
+- Persist middleware for automatic localStorage synchronization (`europarty:session`)
 
 ### Changed
-- Simplified the host observer view UI by removing redundant status information (14 May 2025)
-- Improved player readiness indicator with checkmarks and simplified helper text (14 May 2025)
-- Standardized button styling across components for better UI consistency (14 May 2025)
+- **Lobby component now reads all session state from Zustand instead of localStorage**
+- **Difficulty selection writes to both Firestore (multiplayer sync) and Zustand (local state)**
+- MultiplayerLobby now writes session data to Zustand when creating/joining rooms
+- Replaced fragile navigation state dependencies with centralized store
 
 ### Fixed
-- Fixed scoreboard not updating dynamically for observing hosts when participants answer questions (13 May 2025)
-- Fixed quiz timer issue with duplicate cleanup functions causing timer malfunction when reaching zero (13 May 2025)
-- Removed unused interface definition in HostObserverView component (14 May 2025)
-- Quiz timer functionality that automatically submits after 10 seconds and progresses to next question
-- Visual timer countdown with color change warning when time is running low
-- Auto-progression to next question after time expires
-- Synchronized quiz progression to ensure all participants move to the next question at the same time
-- Automatic question progression with feedback stage between questions
-- Visual feedback for correct/incorrect answers with 5-second display
-- Added timer visibility toggle that hides timer when answer is submitted (13 May 2025)
-- Added proper loading and error states with UI components (13 May 2025)
-- Added high-precision time-based scoring system for multiplayer quizzes (13 May 2025)
-- Added millisecond precision timer for more accurate scoring calculation (13 May 2025)
-- Added points display that shows earned points after answering a question (13 May 2025)
-- Improved points display UI showing as centered text at the top of quiz card (13 May 2025)
-- Added sorted leaderboard to mid-quiz scoreboard with table layout (13 May 2025)
+- Fixed styled-components warning for boolean `secondary` prop in MultiplayerLobby
+- Multiplayer lobby state now persists reliably across page refreshes
+- Players no longer lose room context when refreshing during lobby
+- Removed unused `_playerId` and `_index` variables
 
-### Fixed
-- Fixed bug where observing hosts appeared in player lists and leaderboards (13 May 2025)
-- Fixed bug where quiz participants were incorrectly redirected to the scoreboard instead of the quiz (13 May 2025)
-- Fixed bug where multiple participants could get the same name when joining a room (13 May 2025)
+### Technical
+- **Completed Issue #1: Zustand now manages full session lifecycle (write + read + persist)**
+- Lobby.tsx migration removes all direct localStorage reads for session data
+- Store uses `europarty:session` localStorage key with version 0
+- No TypeScript `any` types in store implementation
 
-### Removed
-- Removed multiplayer badge indicator from the Quiz component
+---
 
-### Fixed
-- Fixed TypeScript errors related to unused variables in Quiz component (13 May 2025)
-- Removed redundant timer state variables for cleaner code (13 May 2025)
-- Optimized Quiz component rendering logic with proper loading and error states (13 May 2025)
-
-### Fixed
-- Resolved issues with timer effect dependencies causing unexpected behavior
-- Fixed Promise handling in score update function to prevent runtime errors
-- Enhanced submit button to switch to "Next Question" with countdown after answer submission (12 May 2025)
-- Removed redundant question counter and status messages for cleaner UI (12 May 2025)
-- Fixed auto-progression after time expiration and improved timer handling with separate question/feedback timers (12 May 2025)
-- Removed text feedback messages for cleaner UI, relying on color coding for answer feedback (12 May 2025)
-- Fixed timer calculation to properly combine remaining question time with feedback time when answer submitted early (12 May 2025)
-- Fixed quiz progression by properly resetting question state when moving to new questions (12 May 2025)
-- Fixed timer and button state when transitioning between questions to ensure a clean reset (12 May 2025)
-- Enforced synchronized quiz progression by preventing manual advancement during feedback phase (12 May 2025)
-
-
-<!-- Add your changes at the top -->
-- Fixed multiplayer quiz difficulty validation issue when using capitalized difficulty levels (11 May 2025)
-- Fixed host name display consistency, now showing "👑 HOST 👑" in all UI locations (11 May 2025)
-- Fixed Lobby component width to be consistent with other cards (11 May 2025)
-- Improved button layout in Lobby with full-width styling for better visual consistency (11 May 2025)
-- Fixed Lobby component color scheme for better readability and consistency with other pages (11 May 2025)
-- Updated buttons in Lobby component with bold text and consistent purple color scheme (11 May 2025)
-- Changed text colors in Lobby to white with purple highlights for important elements (11 May 2025)
-
-- Standardized component styling across the entire application with consistent rem units (11 May 2025)
-- Converted all pixel measurements to rem units for better accessibility and scaling (11 May 2025)
-- Applied consistent square button styling throughout all pages (11 May 2025)
-- Unified container widths to 31.25rem (500px) across all components (11 May 2025)
-- Standardized typography with consistent font sizes and spacing (11 May 2025)
-
-- Redid styling to look more like ESC News with square buttons, brighter colors and larger buttons
-- Redid most pages, but might have some smaller details left which is not fixed.
-- Worked on input validation on join game page, with some user feedback if code is wrong.  
-
-- Fixed input validation feedback in multiplayer game code entry form
-- Fixed MultiplayerLobby UI by cleaning up duplicate buttons and improving layout
-- Improved styling for multiplayer game options with descriptive cards
-- Added proper loading states for game creation and joining (11 May 2025)
-
-
-- Corrected favicon path references to work in both development and production environments (11 May 2025)
-
-- Fixed quiz loading issues in prod making quiz load properly both in dev and prod. (10 May 2025)
-
-
-- Fixed build error by removing unused Firestore collection import (10 May 2025)
-
-- Fixed TypeScript errors in production build by properly handling unused variables (10 May 2025)
-  - Added underscore prefixes to unused variables in Lobby and MultiplayerLobby components 
-  - Enhanced Firebase debugging to provide more detailed error information
-  - Added comprehensive logging to diagnose room creation issues in production build
-
-- Fixed Firebase room creation in production preview by improving environment detection logic (10 May 2025)
-  - Updated pathUtils.ts with proper environment detection using Vite's MODE variable
-  - Enhanced firebase.ts to handle production preview mode correctly
-  - Added debugging logs for easier environment identification
-
-- Fixed question continuity issue after midquiz scoreboard by properly handling the question index state (10 May 2025)
-- Fixed quiz loop issue that caused the quiz to restart from question 1 instead of continuing from question 6
-
-- Fixed quiz loading issues in single and multiplayer modes with improved error handling and timeouts (10 May 2025)
-- Enhanced QuizDataProvider with better debug logging and fallback mechanisms
-- Improved Quiz component with loading progress status and error recovery options
-
-- Fixed Firebase error when creating rooms by replacing serverTimestamp() with Timestamp.now() in arrays (10 May 2025)
-- Updated player data structure to use static timestamps inside Firestore arrays
-- Fixed player joining process to use compatible timestamp objects
-
-- Fixed multiplayer lobby error by adding missing `joinRoom` and `generateRoomCode` functions (10 May 2025)
-- Updated MultiplayerLobby component to correctly use the createRoom function
-- Added extra validation for room joining to prevent joining games that have already started
-
-- Fixed quiz loading issues in development environment with improved multi-method loading strategy (10 May 2025)
-- Added comprehensive debugging and error handling for cross-environment compatibility 
-- Enhanced Firebase initialization for better error detection
-- Added direct JSON import fallback for quiz data in development mode
-- Created built-in fallback quiz data to ensure functionality even when network requests fail
-- Improved Firebase connectivity with better error handling and logging
-- Added environment-specific optimizations for quiz data loading
-
-- Added robust quiz data loading system that works in both development and production (10 May 2025)
-- Created QuizDataProvider with multi-source fallback for reliable quiz loading
-- Fixed path resolution issues in localhost development environment 
-- Improved Vite configuration to correctly handle base paths in different environments
-- Enhanced path utility to leverage Vite's import.meta.env.BASE_URL for consistent asset loading
-- Added comprehensive debug logging to help troubleshoot environment-specific issues
-
-- Fixed app compatibility issues between development and production environments
-- Added path utility system to handle asset paths correctly in both localhost and deployed environments
-- Updated Vite configuration to dynamically set base path according to environment
-- Fixed quiz loading in development environment by using environment-aware asset paths
-- Improved background image loading to work consistently across all environments
-
-- Fixed multiplayer quiz loading issue for participants by implementing session storage for game state persistence
-- Added error handling to gracefully recover from page refreshes during multiplayer games
-- Added multiplayer status indicator in the quiz UI
-- Enhanced state recovery in MidQuizScoreboard and QuizResults for interrupted multiplayer games
-- Improved player score display to highlight the current player in score tables
-
-- Added Firebase Firestore integration for multiplayer quiz rooms
-- Replaced local storage room management with real-time Firestore database
-- Added multiplayer game state synchronization across devices
-- Added player score tracking in Firestore for real-time updates
-- Improved lobby UI with real-time room status updates
-- Added UUID generation for unique player identification
-- Fixed real-time score updates in mid-quiz scoreboard for multiplayer
-- Enhanced QuizResults to show multiplayer game winners
-
-- Fixed TypeScript error with Firebase configuration by moving firebase.ts to the src directory to properly access Vite environment variable types
-- Fixed horizontal scrollbar in quiz pages by changing container width from viewport units to percentage-based units
-- Improved button layout in SelectDifficulty component with proper text wrapping and responsive container
-- Enhanced quiz flow components to properly fit within the MobileFrame container
-- Fixed content sizing within MobileFrame to properly display pages inside the phone UI
-- Updated global styles to ensure all pages adapt to MobileFrame container dimensions
-- Enhanced ContentConstraint component with proper overflow handling and padding
-- Modified Home component sizing to use relative units instead of viewport units
-- Fixed content width constraint in mobile frame to prevent horizontal overflow
-- Fixed full-page background color for desktop view using absolute positioning
-- Added ContentConstraint component to properly contain page content within phone frame
-- Fixed mobile frame styling to prevent horizontal scrolling and ensure content fits properly inside frame
-- Fixed background coloring to cover the entire viewport for desktop view
-- Added mobile phone frame for desktop users to showcase the mobile-first design
-- Improved responsive layout with a simulated phone UI on larger screens
-- Added UnderDevelopment page for the Create Quiz feature
-- Added route for /quiz to show "Feature Under Development" page
-- Fixed navigation issue when clicking "Create Quiz" button
-
-- Fixed asset paths after repository name change from `/europarty/` to `/escparty/`
-- Fixed background image path in Home component
-- Fixed quiz data loading paths in Quiz component
-- Updated favicon and manifest paths in index.html
-
-- Fixed state persistence in quiz flow by ensuring all required data is passed between MidQuizScoreboard and Quiz components
-- Fixed TypeScript error in MidQuizScoreboard component by properly using the currentQuestionIndex variable
-
-## Sprint 6
-- Fixed issues in Mid-Quiz Scoreboard to update player list and scores dynamically.
-- Added setPlayers function to Mid-Quiz Scoreboard to update player list dynamically.
-- Fixed fetch logic in Quiz component to ensure correct URL is used for fetching quiz data.
-- Fixed bug in MidQuizScoreboard where quiz continuation used incorrect URL format causing JSON loading errors.
-- Added state persistence between Quiz and MidQuizScoreboard to maintain question index and score.
-
-## [Current] - 2025-06-17
-
-### Fixed
-- Resolved Firestore security rules blocking multiplayer room join operations
-- Fixed arrayUnion compatibility issues with security rule validation  
-- Fixed permission-denied errors when adding players to game rooms
+## [0.3.0] - 2025-06-17
 
 ### Added
-- Comprehensive Firestore security rules for multiplayer quiz functionality
-- Data validation ensuring proper room and player structure
-- Business logic protection preventing invalid game state changes
-- Enhanced error handling with specific user-friendly messages
+- Host observer mode - hosts can watch multiplayer games without participating
+- Player readiness tracking at mid-quiz scoreboard
+- High-precision millisecond timer for accurate scoring calculation
+- Points display showing earned points after each question
+- Sorted leaderboard with table layout in mid-quiz scoreboard
+- Real-time score updates for observing hosts
+
+### Changed
+- Simplified host observer UI by removing redundant status information
+- Standardized button styling across all components
+- Improved player readiness indicator with checkmarks
+
+### Fixed
+- Firestore security rules now properly allow multiplayer room operations
+- Timer automatically submits answers and progresses to next question
+- Scoreboard updates in real-time for all participants
+- Observing hosts no longer appear in player lists and leaderboards
+- Quiz participants no longer incorrectly redirected to scoreboard
+- Multiple participants can no longer get duplicate names when joining
 
 ### Security
-- Implemented secure Firestore rules that work without user authentication
-- Added protection against malformed data and unauthorized operations
-- Validated all room operations (create, join, start, update scores, etc.)
-- Prevented room deletion and ensured data integrity
+- Implemented comprehensive Firestore security rules without requiring authentication
+- Added data validation for room and player structures
+- Protected against malformed data and unauthorized operations
 
-### Performance
-- Optimized room join process with better error handling
-- Reduced unnecessary Firebase calls through improved validation logic
-- Cleaned up debug logging for production readiness
+---
+
+## [0.2.0] - 2025-05-13
+
+### Added
+- Multiplayer quiz mode with real-time synchronization via Firebase Firestore
+- Room management system with unique room codes
+- UUID-based player identification
+- Mid-quiz scoreboard with leaderboard after every 5 questions
+- Real-time player score tracking across devices
+- Session storage for state persistence during page refreshes
+- Multiplayer status indicator in quiz UI
+
+### Changed
+- Replaced localStorage room management with Firestore database
+- Quiz flow now supports both singleplayer and multiplayer modes
+- Timer system with separate question and feedback phases
+- Answer submission now shows 5-second feedback before progressing
+
+### Fixed
+- Quiz loading works correctly in both development and production
+- Players can rejoin rooms after accidental disconnection
+- State properly persists between Quiz and MidQuizScoreboard components
+- Difficulty validation now handles capitalized difficulty levels
+- Question continuity after mid-quiz scoreboard maintains correct index
+
+---
+
+## [0.1.0] - 2025-05-10
+
+### Added
+- Initial release with single-player quiz functionality
+- Three difficulty levels (easy, medium, hard)
+- 10-second timer per question with time-based scoring bonus
+- Visual feedback for correct/incorrect answers
+- Results screen with final score summary
+- Mobile-first design with simulated phone frame on desktop
+- Quiz data loading with fallback mechanisms
+- Environment-aware asset path handling
+
+### Changed
+- Standardized component styling with consistent rem units
+- Square button design inspired by ESC News
+- Unified container widths to 31.25rem (500px)
+- Converted all measurements from pixels to rem for better accessibility
+
+### Fixed
+- Quiz data loading works in both localhost and production
+- Background images load correctly across environments
+- Proper base path handling via Vite configuration
+- Horizontal scrollbar removed from quiz pages
+- Content properly fits within mobile frame container
+
+---
+
+## [0.0.1] - 2025-01-10
+
+### Added
+- Project initialization
+- Basic quiz structure
+- Routing setup
+- Theme system with styled-components
+
+---
+
+## How to Use This Changelog
+
+- **[Unreleased]**: Features currently in development
+- **[X.Y.Z]**: Released versions (newest first)
+  - **[0.3.0]**: Latest release with multiplayer improvements
+  - **[0.2.0]**: Multiplayer mode introduction
+  - **[0.1.0]**: Initial singleplayer release
+- **Added**: New features
+- **Changed**: Changes to existing functionality
+- **Fixed**: Bug fixes
+- **Security**: Security improvements
+- **Performance**: Performance improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.5",
         "styled-components": "^6.1.15",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -2147,7 +2148,7 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4926,6 +4927,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.5",
     "styled-components": "^6.1.15",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -6,6 +6,9 @@ import { updatePlayerScore, listenToRoom, Room } from "../utils/roomsFirestore";
 import { isDevelopmentEnvironment } from "../utils/pathUtils";
 import { loadQuizData, QuizQuestion, QuizDifficulty } from "../utils/QuizDataProvider";
 
+/**
+ * Multiplayer game data structure stored in sessionStorage for persistence across page refreshes.
+ */
 interface MultiplayerGameData {
   multiplayer: boolean;
   roomCode: string;
@@ -14,6 +17,13 @@ interface MultiplayerGameData {
   hostIsObserver?: boolean;
 }
 
+/**
+ * Main quiz component that handles both single-player and multiplayer quiz gameplay.
+ * Features time-based scoring, real-time multiplayer updates, and automatic progression.
+ * 
+ * @component
+ * @returns The interactive quiz interface with questions, timer, and scoring
+ */
 const Quiz = () => {
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const location = useLocation();
@@ -36,18 +46,17 @@ const Quiz = () => {
   const [playerId, setPlayerId] = useState<string | null>(locationState?.playerId || null);
   const [room, setRoom] = useState<Room | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null); // Used in useEffect and conditional rendering
-  const [loadingStatus, setLoadingStatus] = useState<string>("Initializing..."); // Used in loading state display
-  const [timeLeft, setTimeLeft] = useState(10); // 10 second timer
-  const [timeLeftMs, setTimeLeftMs] = useState(10000); // More precise millisecond timer for scoring
+  const [error, setError] = useState<string | null>(null);
+  const [loadingStatus, setLoadingStatus] = useState<string>("Initializing...");
+  const [timeLeft, setTimeLeft] = useState(10);
+  const [timeLeftMs, setTimeLeftMs] = useState(10000);
   const [showFeedback, setShowFeedback] = useState(false);
   const [isTimerVisible, setIsTimerVisible] = useState(true);
-  const [currentQuestionPoints, setCurrentQuestionPoints] = useState(0); // Points earned for current question
+  const [currentQuestionPoints, setCurrentQuestionPoints] = useState(0);
 
   const navigate = useNavigate();
   const { difficulty } = useParams<{ difficulty: string }>();
 
-  // Calculate current question based on currentQuestionIndex and questions array
   const currentQuestion = !loading && questions.length > 0 && currentQuestionIndex < questions.length
     ? questions[currentQuestionIndex]
     : { question: "", options: [], correctAnswer: "" };
@@ -55,8 +64,6 @@ const Quiz = () => {
   const hostIsObserverFromLocation = locationState?.hostIsObserver;
 
   useEffect(() => {
-    // This effect handles redirection for an observing host.
-    // It depends on data being loaded and relevant states being set.
     if (
       hostIsObserverFromLocation &&
       localStorage.getItem("isHost") === "true" &&
@@ -82,7 +89,7 @@ const Quiz = () => {
           playerId,
           hostIsObserver: true,
         },
-        replace: true, // Replace history to prevent back navigation to the quiz page
+        replace: true,
       });
     }
   }, [
@@ -100,28 +107,25 @@ const Quiz = () => {
   ]);
 
   useEffect(() => {
-    // If the current user is a host in observer mode, redirect to the mid-quiz scoreboard
     if (locationState?.hostIsObserver && localStorage.getItem("isHost") === "true" && roomCode && playerId && difficulty) {
       navigate("/mid-quiz-scoreboard", {
         state: {
-          multiplayer: true, // Host observer implies a multiplayer context
+          multiplayer: true,
           roomCode: roomCode,
           playerId: playerId,
           difficulty: difficulty,
-          hostIsObserver: true, // Explicitly set for the scoreboard
+          hostIsObserver: true,
         },
-        replace: true // Replace the current entry in history
+        replace: true
       });
     }
   }, [locationState, roomCode, playerId, difficulty, navigate]);
 
   useEffect(() => {
-    // Clear any previous errors when component mounts or difficulty changes
     setError(null);
     setLoading(true);
     setLoadingStatus("Initializing quiz...");
 
-    // Track component mounting for debug purposes
     console.log("🚀 Quiz component mounted", {
       mode: import.meta.env.MODE,
       baseUrl: import.meta.env.BASE_URL,
@@ -131,7 +135,6 @@ const Quiz = () => {
       currentQuestionIndex
     });
 
-    // Handle case when difficulty is undefined or invalid
     if (!difficulty || !['easy', 'medium', 'hard'].includes(difficulty)) {
       console.error(`❌ Invalid difficulty parameter: ${difficulty}`);
       setError(`Invalid difficulty level: ${difficulty}`);
@@ -139,10 +142,8 @@ const Quiz = () => {
       return;
     }
 
-    // Process multiplayer data
     let multiplayerData: MultiplayerGameData | null = null;
 
-    // First try to get multiplayer data from location state
     if (locationState?.multiplayer) {
       console.log("📱 Multiplayer data found in location state:", locationState);
       multiplayerData = {
@@ -151,7 +152,6 @@ const Quiz = () => {
         playerId: locationState.playerId || ''
       };
     } else {
-      // If not in location state, check sessionStorage (for page refreshes or direct navigation)
       const storedData = sessionStorage.getItem('multiplayerGame');
       if (storedData) {
         try {
@@ -163,7 +163,6 @@ const Quiz = () => {
       }
     }
 
-    // Set multiplayer state if we have valid data
     let unsubscribeRoom: () => void = () => { };
     if (multiplayerData?.multiplayer && multiplayerData.roomCode && multiplayerData.playerId) {
       console.log("🔄 Setting up multiplayer mode...");
@@ -172,37 +171,30 @@ const Quiz = () => {
       setPlayerId(multiplayerData.playerId);
       setLoadingStatus("Connecting to game room...");
 
-      // Store multiplayer info in session storage (for page refresh recovery)
       sessionStorage.setItem('multiplayerGame', JSON.stringify(multiplayerData));
 
-      // Set up listener for room changes in multiplayer
       unsubscribeRoom = listenToRoom(multiplayerData.roomCode, (roomData) => {
         if (roomData) {
           console.log("🎮 Room data updated:", roomData);
           setRoom(roomData);
 
-          // If we get room data with difficulty, use it as backup
           if (!difficulty && roomData.difficulty) {
             console.log(`Using room difficulty: ${roomData.difficulty}`);
           }
         } else {
           console.error("❌ Game room not found");
-          // Room doesn't exist, go back to multiplayer lobby
           setError("Game room no longer exists");
           setTimeout(() => navigate("/multiplayer"), 2000);
         }
       });
     }
 
-    // Enhanced debugging
     console.log(`🌐 Environment: ${isDevelopmentEnvironment() ? 'Development' : 'Production'}`);
     console.log(`📂 Base URL: ${import.meta.env.BASE_URL}`);
     console.log(`🎮 Difficulty parameter: ${difficulty}`);
 
-    // Load quiz data using our QuizDataProvider
     setLoadingStatus("Loading quiz data...");
 
-    // Use Promise.race with a timeout to prevent infinite loading
     const quizLoaderPromise = loadQuizData(difficulty as QuizDifficulty);
     const timeoutPromise = new Promise<never>((_, reject) => {
       setTimeout(() => reject(new Error('Quiz loading timed out after 10 seconds')), 10000);
@@ -230,8 +222,6 @@ const Quiz = () => {
         setQuestions(filteredQuestions);
         setLoading(false);
 
-        // We now use the state initialized at the component level
-        // instead of trying to retrieve it from localStorage
         console.log(`Using question index: ${currentQuestionIndex}, score: ${score}`);
       })
       .catch((error) => {
@@ -240,35 +230,31 @@ const Quiz = () => {
         setLoading(false);
       });
 
-    // Cleanup function
     return () => {
-      // Clean up room listener if it was set
       unsubscribeRoom();
       console.log("🧹 Quiz component unmounting, cleaned up listeners");
     };
-  }, [difficulty, navigate, location, currentQuestionIndex, score]);  // Timer effect for question countdown
+  }, [difficulty, navigate, location, currentQuestionIndex, score]);
+
   useEffect(() => {
     if (quizCompleted || loading) return;
 
-    // Only start a new timer if we're in question mode (not feedback mode)
     if (!showFeedback) {
       console.log("Setting up new question timer");
       setTimeLeft(10);
       setTimeLeftMs(10000);
 
-      // Use a more precise interval for millisecond timer (100ms)
       const msTimer = setInterval(() => {
         setTimeLeftMs(prev => {
-          if (prev <= 100) { // When 0.1 seconds left
+          if (prev <= 100) {
             clearInterval(msTimer);
             handleTimeUp();
             return 0;
           }
-          return prev - 100; // Decrease by 100ms each time
+          return prev - 100;
         });
       }, 100);
 
-      // Regular timer for visible UI updates (every second)
       const uiTimer = setInterval(() => {
         setTimeLeft(prev => {
           if (prev <= 1) {
@@ -279,21 +265,20 @@ const Quiz = () => {
         });
       }, 1000);
 
-      // Return cleanup function for both timers
       return () => {
         clearInterval(msTimer);
         clearInterval(uiTimer);
       };
     }
-  }, [currentQuestionIndex, quizCompleted, loading, showFeedback]);  // Separate effect for feedback timer that automatically moves to next question
+  }, [currentQuestionIndex, quizCompleted, loading, showFeedback]);
+
   useEffect(() => {
     if (showFeedback) {
-      // Note: We don't reset time here - it's set in submitAnswer or handleTimeUp
       const feedbackTimer = setInterval(() => {
         setTimeLeft(prev => {
           if (prev <= 1) {
             clearInterval(feedbackTimer);
-            moveToNextQuestion(); // Automatically move to next question when feedback time ends
+            moveToNextQuestion();
             return 0;
           }
           return prev - 1;
@@ -306,26 +291,22 @@ const Quiz = () => {
     }
   }, [showFeedback]);
 
-  // Function to handle when the time is up but before showing feedback
+  /**
+   * Handles the timer expiration when a question times out.
+   * Marks the question as submitted, hides the timer, awards 0 points, and shows feedback.
+   */
   const handleTimeUp = () => {
     if (!isSubmitted) {
       setIsSubmitted(true);
     }
 
-    // Hide timer after time is up
     setIsTimerVisible(false);
-
-    // Set points to 0 for unanswered question
     setCurrentQuestionPoints(0);
-
-    // Show answer feedback for 5 seconds
     setShowFeedback(true);
     setTimeLeft(5);
 
-    // If multiplayer, update score
     if (isMultiplayer && roomCode && playerId) {
       try {
-        // Using void to ignore the promise result
         void updatePlayerScore(roomCode, playerId, score).catch(error => {
           console.error("Failed to update score:", error);
         });
@@ -335,7 +316,11 @@ const Quiz = () => {
     }
   };
 
-  // Function to automatically move to the next question
+  /**
+   * Advances to the next question or shows the scoreboard/results.
+   * After every 5 questions, navigates to mid-quiz scoreboard.
+   * After all questions, saves scores and navigates to final results.
+   */
   const moveToNextQuestion = () => {
     if (currentQuestionIndex < questions.length - 1) {
       if ((currentQuestionIndex + 1) % 5 === 0) {
@@ -352,15 +337,14 @@ const Quiz = () => {
           }
         });
       } else {
-        // Reset all question-related states
-        setShowFeedback(false); // Must be reset before setting new question
+        setShowFeedback(false);
         setCurrentQuestionIndex(currentQuestionIndex + 1);
         setSelectedAnswer(null);
         setIsSubmitted(false);
-        setTimeLeft(10); // Reset timer for new question
-        setTimeLeftMs(10000); // Reset precise timer for new question
-        setIsTimerVisible(true); // Show timer again for the next question
-        setCurrentQuestionPoints(0); // Reset points for new question
+        setTimeLeft(10);
+        setTimeLeftMs(10000);
+        setIsTimerVisible(true);
+        setCurrentQuestionPoints(0);
       }
     } else {
       const difficultyLevel = difficulty ?? "easy";
@@ -390,34 +374,41 @@ const Quiz = () => {
     }
   };
 
+  /**
+   * Handles answer selection by the user.
+   * Only allows selection if the question hasn't been submitted yet.
+   * 
+   * @param answer - The selected answer option
+   */
   const handleAnswer = (answer: string) => {
     if (!isSubmitted) {
       setSelectedAnswer(answer);
     }
   };
 
+  /**
+   * Submits the selected answer and calculates the score.
+   * Awards base 500 points + time bonus (up to 500 points) for correct answers.
+   * Updates multiplayer scores in real-time via Firestore.
+   * 
+   * @param answer - The answer to submit
+   */
   const submitAnswer = async (answer: string) => {
     if (!answer) return;
 
     setIsSubmitted(true);
-    setIsTimerVisible(false); // Hide timer when answer is submitted
+    setIsTimerVisible(false);
 
-    // Check if answer is correct and calculate time-based score
     if (answer === currentQuestion.correctAnswer) {
-      // Calculate time-based score with millisecond precision
-      // Base score of 500 + up to 500 more based on time remaining
       const timeBonus = Math.floor((timeLeftMs / 10000) * 500);
-      // Using timeLeftMs (milliseconds) for more precise scoring
       const pointsForAnswer = 500 + timeBonus;
       console.log(`Correct answer! Time left: ${timeLeftMs / 1000}s, Time bonus: ${timeBonus}, Total points: ${pointsForAnswer}`);
 
-      // Set points for current question to display in the UI
       setCurrentQuestionPoints(pointsForAnswer);
 
       const newScore = score + pointsForAnswer;
       setScore(newScore);
 
-      // If multiplayer, update score in Firestore
       if (isMultiplayer && roomCode && playerId) {
         try {
           await updatePlayerScore(roomCode, playerId, newScore);
@@ -426,24 +417,24 @@ const Quiz = () => {
         }
       }
     } else {
-      // If answer is incorrect, set points to 0
       setCurrentQuestionPoints(0);
     }
 
-    // Show feedback after submission
-    // Add remaining question time PLUS 5 seconds for feedback
     const feedbackTime = Math.min(timeLeft, 10) + 5;
     setShowFeedback(true);
     setTimeLeft(feedbackTime);
   };
 
+  /**
+   * Resets the quiz to its initial state for replay.
+   */
   const restartQuiz = () => {
     setCurrentQuestionIndex(0);
     setScore(0);
     setQuizCompleted(false);
     setSelectedAnswer(null);
     setIsSubmitted(false);
-    setIsTimerVisible(true); // Show timer when restarting the quiz
+    setIsTimerVisible(true);
   };
 
   // Render loading state
@@ -522,14 +513,13 @@ const Quiz = () => {
 
 export default Quiz;
 
-// Styled Components
 const Container = styled.div`
   position: relative;
   width: 100%;
-  max-width: 31.25rem; /* 500px */
+  max-width: 31.25rem;
   margin: auto;
   text-align: center;
-  padding: 1.25rem; /* 20px */
+  padding: 1.25rem;
   background: ${({ theme }) => theme.colors.magnolia};
   overflow-x: hidden;
 `;
@@ -561,7 +551,7 @@ const TimerContainer = styled.div<{ $timeRunningOut: boolean; $isFeedback: boole
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  display: flex; /* Always display the container to maintain layout */
+  display: flex;
   align-items: center;
   justify-content: center;
   background-color: ${({ $timeRunningOut, $isFeedback, theme }) =>
@@ -588,7 +578,7 @@ const QuestionText = styled.h2`
   font-family: ${({ theme }) => theme.fonts.heading};
   color: ${({ theme }) => theme.colors.night};
   font-size: 1.5rem;
-  margin-bottom: 1.25rem; /* 20px */
+  margin-bottom: 1.25rem;
 `;
 
 const OptionsContainer = styled.div`
@@ -621,7 +611,7 @@ const OptionButton = styled.button<{ $isSelected: boolean; $isCorrect: boolean; 
 `;
 
 const SubmitButton = styled.button`
-  margin-top: 1.25rem; /* 20px */
+  margin-top: 1.25rem;
   background: ${({ theme }) => theme.colors.purple};
   color: white;
   font-size: 1rem;
@@ -647,26 +637,26 @@ const LoadingContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem 1.25rem; /* 40px 20px */
+  padding: 2.5rem 1.25rem;
   background: ${({ theme }) => theme.colors.magnolia};
   border-radius: 0;
   margin: auto;
-  max-width: 31.25rem; /* 500px */
+  max-width: 31.25rem;
 `;
 
 const Loading = styled.p`
   text-align: center;
   font-size: 1.2rem;
   color: ${({ theme }) => theme.colors.night};
-  margin-top: 1.25rem; /* 20px */
+  margin-top: 1.25rem;
 `;
 
 const LoadingSpinner = styled.div`
-  border: 0.25rem solid rgba(0, 0, 0, 0.1); /* 4px */
+  border: 0.25rem solid rgba(0, 0, 0, 0.1);
   border-radius: 50%;
-  border-top: 0.25rem solid ${({ theme }) => theme.colors.amethyst}; /* 4px */
-  width: 2.5rem; /* 40px */
-  height: 2.5rem; /* 40px */
+  border-top: 0.25rem solid ${({ theme }) => theme.colors.amethyst};
+  width: 2.5rem;
+  height: 2.5rem;
   animation: spin 1s linear infinite;
 
   @keyframes spin {
@@ -679,18 +669,18 @@ const ScoreText = styled.p`
   font-size: 1.5rem;
   font-weight: bold;
   color: ${({ theme }) => theme.colors.amethyst};
-  margin-bottom: 1.25rem; /* 20px */
+  margin-bottom: 1.25rem;
 `;
 
 const QuitButton = styled.button`
   position: relative;
-  margin-top: 1.25rem; /* 20px */
+  margin-top: 1.25rem;
   background: ${({ theme }) => theme.colors.darkpurple};
   color: white;
   border: none;
   border-radius: 50%;
-  width: 2.5rem; /* 40px */
-  height: 2.5rem; /* 40px */
+  width: 2.5rem;
+  height: 2.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -704,23 +694,23 @@ const QuitButton = styled.button`
 
 const ErrorContainer = styled.div`
   width: 100%;
-  max-width: 31.25rem; /* 500px */
+  max-width: 31.25rem;
   margin: auto;
   text-align: center;
-  padding: 2.5rem 1.25rem; /* 40px 20px */
+  padding: 2.5rem 1.25rem;
   background: ${({ theme }) => theme.colors.magnolia};
-  border-radius: 0; /* Changed from 10px to match square design */
+  border-radius: 0;
 `;
 
 const ErrorMessage = styled.p`
   color: ${({ theme }) => theme.colors.incorrectRed};
   font-size: 1.2rem;
-  margin-bottom: 1.25rem; /* 20px */
+  margin-bottom: 1.25rem;
 `;
 
 const RetryButton = styled(SubmitButton)`
-  max-width: 12.5rem; /* 200px */
-  margin: 0.625rem auto; /* 10px auto */
+  max-width: 12.5rem;
+  margin: 0.625rem auto;
   display: block;
 `;
 

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -4,24 +4,28 @@ import styled, { keyframes } from "styled-components";
 import { listenToRoom, Room, setRoomDifficulty, startGame } from "../utils/roomsFirestore";
 import { useGameSession } from "../store/gameSession";
 
+/**
+ * Multiplayer game lobby where players wait for the host to start the game.
+ * Displays connected players, allows host to select difficulty, and manages game state transitions.
+ * 
+ * @component
+ * @returns The lobby interface with player list and game controls
+ */
 const Lobby = () => {
     const navigate = useNavigate();
 
-    // Read from Zustand store
     const roomCode = useGameSession((state) => state.roomCode);
     const playerId = useGameSession((state) => state.playerId);
     const playerName = useGameSession((state) => state.playerName);
     const isHost = useGameSession((state) => state.isHost);
-    const hostIsObserver = useGameSession((state) => state.hostIsObserver); // ← Remove underscore
+    const hostIsObserver = useGameSession((state) => state.hostIsObserver);
     const setDifficulty = useGameSession((state) => state.setDifficulty);
 
-    // Local component state
     const [room, setRoom] = useState<Room | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
-        // Safety check
         if (!roomCode || !playerId) {
             console.error("Missing roomCode or playerId, redirecting to multiplayer");
             setError("Missing game data. Returning to multiplayer lobby.");
@@ -29,26 +33,18 @@ const Lobby = () => {
             return;
         }
 
-        // Set up real-time listener
         const unsubscribe = listenToRoom(roomCode, (roomData) => {
             if (roomData) {
                 setRoom(roomData);
                 setLoading(false);
 
-                // Check if game started
                 if (roomData.started) {
-                    // === CHANGE THIS LINE ===
-                    // const isCurrentUserObserver = isHost && roomData.hostIsObserver;
-                    
-                    // === TO THIS (use Zustand as source of truth) ===
                     const isCurrentUserObserver = isHost && hostIsObserver;
 
-                    // Write difficulty to Zustand
                     if (roomData.difficulty) {
                         setDifficulty(roomData.difficulty as 'easy' | 'medium' | 'hard');
                     }
 
-                    // Keep sessionStorage for backward compatibility (temporary)
                     sessionStorage.setItem("multiplayerGame", JSON.stringify({
                         multiplayer: true,
                         roomCode: roomCode,
@@ -73,8 +69,14 @@ const Lobby = () => {
         });
 
         return () => unsubscribe();
-    }, [roomCode, playerId, isHost, hostIsObserver, navigate, setDifficulty]); // ← Add hostIsObserver
+    }, [roomCode, playerId, isHost, hostIsObserver, navigate, setDifficulty]);
 
+    /**
+     * Handles difficulty selection by the host.
+     * Updates both Firestore and local Zustand store with the selected difficulty.
+     * 
+     * @param displayDifficulty - The difficulty level to set ('Easy', 'Medium', or 'Hard')
+     */
     const handleSelectDifficulty = async (displayDifficulty: string) => {
         if (isHost && roomCode) {
             const difficulty = displayDifficulty.toLowerCase();
@@ -88,6 +90,11 @@ const Lobby = () => {
         }
     };
 
+    /**
+     * Initiates the game start process.
+     * Only available to the host after difficulty has been selected.
+     * Updates Firestore to signal all players to navigate to the quiz.
+     */
     const handleStartGame = async () => {
         if (isHost && roomCode) {
             try {
@@ -103,7 +110,6 @@ const Lobby = () => {
         }
     };
 
-    // Safety check
     if (!roomCode || !playerId) {
         return (
             <Container>
@@ -168,7 +174,6 @@ const Lobby = () => {
 
 export default Lobby;
 
-// Styled Components (unchanged)
 const Container = styled.div`
     text-align: center;
     padding: 1.25rem;

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -2,51 +2,57 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled, { keyframes } from "styled-components";
 import { listenToRoom, Room, setRoomDifficulty, startGame } from "../utils/roomsFirestore";
+import { useGameSession } from "../store/gameSession";
 
 const Lobby = () => {
-    const [room, setRoom] = useState<Room | null>(null);
-    const [isHost, setIsHost] = useState<boolean>(false);
-    const [gameCode, setGameCode] = useState<string | null>(null);
-    const [playerName, setPlayerName] = useState<string | null>(null);
-    const [_playerId, setPlayerId] = useState<string | null>(null); // Renamed to _playerId to indicate it's not used directly
-    const [error, setError] = useState<string | null>(null);
-    const [loading, setLoading] = useState<boolean>(true);
     const navigate = useNavigate();
 
-    useEffect(() => {
-        // Get user data from localStorage
-        const storedGameCode = localStorage.getItem("gameCode");
-        const storedPlayerId = localStorage.getItem("playerId");
-        const storedPlayerName = localStorage.getItem("playerName");
-        const storedIsHost = localStorage.getItem("isHost") === "true";
+    // Read from Zustand store
+    const roomCode = useGameSession((state) => state.roomCode);
+    const playerId = useGameSession((state) => state.playerId);
+    const playerName = useGameSession((state) => state.playerName);
+    const isHost = useGameSession((state) => state.isHost);
+    const hostIsObserver = useGameSession((state) => state.hostIsObserver); // ← Remove underscore
+    const setDifficulty = useGameSession((state) => state.setDifficulty);
 
-        if (!storedGameCode || !storedPlayerId || !storedPlayerName) {
+    // Local component state
+    const [room, setRoom] = useState<Room | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        // Safety check
+        if (!roomCode || !playerId) {
+            console.error("Missing roomCode or playerId, redirecting to multiplayer");
             setError("Missing game data. Returning to multiplayer lobby.");
             setTimeout(() => navigate("/multiplayer"), 2000);
             return;
         }
 
-        setGameCode(storedGameCode);
-        setPlayerId(storedPlayerId);
-        setPlayerName(storedPlayerName);
-        setIsHost(storedIsHost);
-
-        // Set up real-time listener for room changes
-        const unsubscribe = listenToRoom(storedGameCode, (roomData) => {
+        // Set up real-time listener
+        const unsubscribe = listenToRoom(roomCode, (roomData) => {
             if (roomData) {
                 setRoom(roomData);
                 setLoading(false);
 
-                // Check if game has started
+                // Check if game started
                 if (roomData.started) {
-                    // Save essentials to sessionStorage to persist through page refresh 
-                    // Only pass hostIsObserver=true if the current user is the host and host is observer
-                    const isCurrentUserObserver = storedIsHost && roomData.hostIsObserver || false;
+                    // === CHANGE THIS LINE ===
+                    // const isCurrentUserObserver = isHost && roomData.hostIsObserver;
+                    
+                    // === TO THIS (use Zustand as source of truth) ===
+                    const isCurrentUserObserver = isHost && hostIsObserver;
 
+                    // Write difficulty to Zustand
+                    if (roomData.difficulty) {
+                        setDifficulty(roomData.difficulty as 'easy' | 'medium' | 'hard');
+                    }
+
+                    // Keep sessionStorage for backward compatibility (temporary)
                     sessionStorage.setItem("multiplayerGame", JSON.stringify({
                         multiplayer: true,
-                        roomCode: storedGameCode,
-                        playerId: storedPlayerId,
+                        roomCode: roomCode,
+                        playerId: playerId,
                         difficulty: roomData.difficulty,
                         hostIsObserver: isCurrentUserObserver
                     }));
@@ -54,8 +60,8 @@ const Lobby = () => {
                     navigate(`/quiz/${roomData.difficulty}`, {
                         state: {
                             multiplayer: true,
-                            roomCode: storedGameCode,
-                            playerId: storedPlayerId,
+                            roomCode: roomCode,
+                            playerId: playerId,
                             hostIsObserver: isCurrentUserObserver
                         }
                     });
@@ -66,16 +72,15 @@ const Lobby = () => {
             }
         });
 
-        // Clean up listener when component unmounts
         return () => unsubscribe();
-    }, [navigate]);
+    }, [roomCode, playerId, isHost, hostIsObserver, navigate, setDifficulty]); // ← Add hostIsObserver
 
     const handleSelectDifficulty = async (displayDifficulty: string) => {
-        if (isHost && gameCode) {
-            // Convert to lowercase for internal storage while keeping display capitalized
+        if (isHost && roomCode) {
             const difficulty = displayDifficulty.toLowerCase();
             try {
-                await setRoomDifficulty(gameCode, difficulty);
+                await setRoomDifficulty(roomCode, difficulty);
+                setDifficulty(difficulty as 'easy' | 'medium' | 'hard');
             } catch (error) {
                 console.error("Error setting difficulty:", error);
                 setError("Failed to set difficulty");
@@ -84,19 +89,28 @@ const Lobby = () => {
     };
 
     const handleStartGame = async () => {
-        if (isHost && gameCode) {
+        if (isHost && roomCode) {
             try {
                 if (!room?.difficulty) {
                     alert("Please select a difficulty first!");
                     return;
                 }
-                await startGame(gameCode);
+                await startGame(roomCode);
             } catch (error) {
                 console.error("Error starting game:", error);
                 setError("Failed to start game");
             }
         }
     };
+
+    // Safety check
+    if (!roomCode || !playerId) {
+        return (
+            <Container>
+                <Title>Redirecting...</Title>
+            </Container>
+        );
+    }
 
     if (loading) {
         return (
@@ -120,12 +134,11 @@ const Lobby = () => {
             <Title>Quiz Lobby</Title>
             {playerName && <PlayerName>You are: <Highlight>{playerName}</Highlight></PlayerName>}
             <GameInfo>
-                <InfoItem>Game Code: <Code>{gameCode}</Code></InfoItem>
+                <InfoItem>Game Code: <Code>{roomCode}</Code></InfoItem>
                 <InfoItem>Difficulty: <Difficulty>{room?.difficulty ? room.difficulty.charAt(0).toUpperCase() + room.difficulty.slice(1) : "Not selected"}</Difficulty></InfoItem>
             </GameInfo>
             <AnimatedSubtitle>Waiting for players...</AnimatedSubtitle>
 
-            {/* If host and difficulty not selected, show difficulty options */}
             {isHost && !room?.difficulty && (
                 <DifficultySection>
                     <SubTitle>Select Difficulty:</SubTitle>
@@ -141,7 +154,7 @@ const Lobby = () => {
             <PlayerList>
                 {room?.players
                     .filter(player => !(room.hostIsObserver && player.id === room.hostId))
-                    .map((player, _index) => (
+                    .map((player) => (
                         <Player key={player.id}>
                             {player.name}
                         </Player>
@@ -155,49 +168,49 @@ const Lobby = () => {
 
 export default Lobby;
 
-// Styled Components
+// Styled Components (unchanged)
 const Container = styled.div`
     text-align: center;
-    padding: 1.25rem; /* 20px */
+    padding: 1.25rem;
     width: 100%;
-    max-width: 31.25rem; /* 500px */
+    max-width: 31.25rem;
     margin: auto;
     background: ${({ theme }) => theme.colors.nightblue};
     color: ${({ theme }) => theme.colors.magnolia};
-    border-radius: 0; /* Making consistent with square design */
+    border-radius: 0;
 `;
 
 const Title = styled.h2`
     font-size: 2rem;
-    margin-bottom: 1.25rem; /* 20px */
+    margin-bottom: 1.25rem;
     font-family: ${({ theme }) => theme.fonts.heading};
-    color: ${({ theme }) => theme.colors.white}; /* Changed to white */
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const GameInfo = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.625rem; /* 10px */
-    margin: 0.9375rem 0; /* 15px 0 */
+    gap: 0.625rem;
+    margin: 0.9375rem 0;
     width: 100%;
 `;
 
 const InfoItem = styled.p`
     font-size: 1.2rem;
-    margin: 0.3125rem 0; /* 5px 0 */
-    color: ${({ theme }) => theme.colors.white}; /* Explicitly set to white */
+    margin: 0.3125rem 0;
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const Code = styled.span`
     font-weight: bold;
-    color: ${({ theme }) => theme.colors.brightpurple}; /* Changed to purple */
+    color: ${({ theme }) => theme.colors.brightpurple};
     font-size: 1.4rem;
 `;
 
 const Difficulty = styled.span`
     font-weight: bold;
-    color: ${({ theme }) => theme.colors.brightpurple}; /* Changed to purple */
+    color: ${({ theme }) => theme.colors.brightpurple};
     font-size: 1.2rem;
 `;
 
@@ -206,39 +219,39 @@ const PlayerListTitle = styled.h3`
     margin-top: 1em;
     text-align: left;
     text-decoration: underline;
-    color: ${({ theme }) => theme.colors.white}; /* Changed to white */
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const Highlight = styled.span`
     font-weight: bold;
-    color: ${({ theme }) => theme.colors.brightpurple}; /* Changed to purple */
+    color: ${({ theme }) => theme.colors.brightpurple};
 `;
 
 const PlayerList = styled.ul`
     list-style: none;
     padding: 0;
     text-align: left;
-    margin: 1.25rem 0; /* 20px 0 */
+    margin: 1.25rem 0;
     width: 100%;
 `;
 
 const Player = styled.li`
     font-size: 1.2rem;
-    margin: 0.3125rem 0; /* 5px 0 */
-    color: ${({ theme }) => theme.colors.white}; /* Explicitly set to white */
+    margin: 0.3125rem 0;
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const StartButton = styled.button`
-    margin-top: 1.25rem; /* 20px */
-    padding: 1rem 1.25rem; /* 16px 20px */
+    margin-top: 1.25rem;
+    padding: 1rem 1.25rem;
     font-size: 1.2rem;
-    background-color: ${({ theme }) => theme.colors.purple}; /* Changed to purple */
+    background-color: ${({ theme }) => theme.colors.purple};
     color: white;
     border: none;
     cursor: pointer;
     border-radius: 0;
     transition: 0.3s;
-    font-weight: bold; /* Added bold text */
+    font-weight: bold;
     width: 100%;
     &:hover {
         background: ${({ theme }) => theme.colors.darkpurple};
@@ -246,10 +259,10 @@ const StartButton = styled.button`
 `;
 
 const PlayerName = styled.p`
-    margin-top: 1.25rem; /* 20px */
+    margin-top: 1.25rem;
     font-size: 1.2rem;
     font-weight: bold;
-    color: ${({ theme }) => theme.colors.white}; /* Changed to white */
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const blink = keyframes`
@@ -267,40 +280,40 @@ const AnimatedSubtitle = styled.p`
 const ErrorMessage = styled.p`
     color: ${({ theme }) => theme.colors.incorrectRed};
     font-size: 1.2rem;
-    margin: 1.25rem 0; /* 20px 0 */
+    margin: 1.25rem 0;
 `;
 
 const DifficultySection = styled.div`
-    margin: 1.25rem 0; /* 20px 0 */
-    padding: 0.625rem; /* 10px */
+    margin: 1.25rem 0;
+    padding: 0.625rem;
     background: rgba(255, 255, 255, 0.1);
-    border-radius: 0; /* Making consistent with square design */
+    border-radius: 0;
     width: 100%;
 `;
 
 const SubTitle = styled.h3`
     font-size: 1.2rem;
-    margin-bottom: 0.9375rem; /* 15px */
-    color: ${({ theme }) => theme.colors.white}; /* Changed to white */
+    margin-bottom: 0.9375rem;
+    color: ${({ theme }) => theme.colors.white};
 `;
 
 const ButtonGroup = styled.div`
     display: flex;
     justify-content: space-between;
-    gap: 0.625rem; /* 10px */
+    gap: 0.625rem;
     flex-wrap: wrap;
     width: 100%;
 `;
 
 const DifficultyButton = styled.button`
-    padding: 0.5rem 1rem; /* 8px 16px */
-    background-color: ${({ theme }) => theme.colors.purple}; /* Changed to purple */
+    padding: 0.5rem 1rem;
+    background-color: ${({ theme }) => theme.colors.purple};
     color: white;
     border: none;
     border-radius: 0;
     cursor: pointer;
     transition: 0.3s;
-    font-weight: bold; /* Added bold text */
+    font-weight: bold;
     flex: 1;
     
     &:hover {

--- a/src/pages/MultiplayerLobby.tsx
+++ b/src/pages/MultiplayerLobby.tsx
@@ -5,11 +5,26 @@ import { v4 as uuidv4 } from "uuid";
 import { createRoom, joinRoom, generateRoomCode, getRoom } from "../utils/roomsFirestore";
 import { useGameSession } from "../store/gameSession"; 
 
-// List of Eurovision Song Contest winners for random name assignment
+/**
+ * List of Eurovision Song Contest winners used for random player name assignment.
+ * Prevents duplicate names in the same room by selecting available winners.
+ */
 const ESC_WINNERS = [
   "Loreen 🇸🇪", "Måneskin 🇮🇹", "Conchita Wurst 🕊️", "Alexander Rybak 🎻", "ABBA 🇸🇪", "Duncan Laurence 🎹", "Netta 🐔", "Dana International 🏳️‍🌈", "Céline Dion 🇨🇭", "Johnny Logan 🇮🇪", "Ruslana 🔥", "Lena 🇩🇪", "Lordi 👹", "Eleni Foureira 🔥", "Helena Paparizou 🇬🇷", "Marija Šerifović 🌈", "Emmelie de Forest 🎤", "Verka Serduchka 🌟", "Mahmood 🇮🇹", "Käärijä 💚", "Chanel 💃", "Barbara Pravi 🇫🇷", "Cornelia Jakobs 🌌", "Salvador Sobral 🕊️", "Noa Kirel 🦄", "Teya & Salena 🧪", "KEiiNO 🐺", "Benjamin Ingrosso 💫", "Subwoolfer 🚀", "Daði Freyr 🧔", "Rosa Linn 🧵", "Marco Mengoni 🎙️", "Gjon's Tears 😢", "Alessandra 👑", "Sam Ryder 🚀", "Go_A 🌿", "S10 🌧️", "Sergey Lazarev 💎", "Stefania 🐎", "Il Volo 🎶"
 ];
 
+/**
+ * Generates a unique player name from the provided list, ensuring no duplicates in the room.
+ * If all names are taken, appends a random number to a random name.
+ * 
+ * @param roomCode - The 4-letter room code to check for existing players
+ * @param namesList - Array of available names to choose from
+ * @returns A unique player name
+ * 
+ * @example
+ * const name = await getUniquePlayerName("ABCD", ESC_WINNERS);
+ * // Returns: "Loreen 🇸🇪" or "Måneskin 🇮🇹 #42" if all names taken
+ */
 const getUniquePlayerName = async (roomCode: string, namesList: string[]): Promise<string> => {
   const room = await getRoom(roomCode);
 
@@ -28,12 +43,18 @@ const getUniquePlayerName = async (roomCode: string, namesList: string[]): Promi
   return availableNames[Math.floor(Math.random() * availableNames.length)];
 };
 
+/**
+ * Multiplayer lobby component for creating or joining quiz games.
+ * Allows users to either host a new game (as player or observer) or join an existing game with a code.
+ * 
+ * @component
+ * @returns The multiplayer lobby interface
+ */
 const MultiplayerLobby = () => {
   const setMultiplayer = useGameSession((state) => state.setMultiplayerMode);
   const setPlayerIdentity = useGameSession((state) => state.setPlayerIdentity);
   const setRoomInfo = useGameSession((state) => state.setRoomInfo);
   
-  // Local component state
   const [joinCode, setJoinCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [showJoinForm, setShowJoinForm] = useState(false);
@@ -41,6 +62,12 @@ const MultiplayerLobby = () => {
   const [attempted, setAttempted] = useState(false);
   const navigate = useNavigate();
 
+  /**
+   * Creates a new multiplayer game room with a unique code.
+   * Sets up the host player identity and navigates to the lobby.
+   * 
+   * @param hostIsObserver - Whether the host should join as an observer (non-playing role)
+   */
   const createGame = async (hostIsObserver: boolean) => {
     setLoading(true);
     try {
@@ -50,12 +77,11 @@ const MultiplayerLobby = () => {
 
       await createRoom(newGameCode, hostId, hostName, hostIsObserver);
 
-      // Write to Zustand
       setMultiplayer(true);
       setPlayerIdentity(hostId, hostName, true);
       setRoomInfo(newGameCode, hostIsObserver);
 
-      // Keep old localStorage for backward compatibility (temporary)
+      // Keep old localStorage for backward compatibility (temporary) TODO: remove later
       localStorage.setItem("playerId", hostId);
       localStorage.setItem("playerName", hostName);
       localStorage.setItem("gameCode", newGameCode);
@@ -71,10 +97,17 @@ const MultiplayerLobby = () => {
     }
   };
 
+  /**
+   * Displays the create game options (Host & Play vs Host Only).
+   */
   const handleShowCreateOptions = () => {
     setShowCreateOptions(true);
   };
 
+  /**
+   * Joins an existing multiplayer game using a room code.
+   * Validates the code format and assigns a random player name.
+   */
   const joinGame = async () => {
     setAttempted(true);
 
@@ -126,10 +159,16 @@ const MultiplayerLobby = () => {
     }
   };
 
+  /**
+   * Displays the join game form.
+   */
   const handleShowJoinForm = () => {
     setShowJoinForm(true);
   };
 
+  /**
+   * Returns to the initial create/join options screen.
+   */
   const handleBackToOptions = () => {
     setShowJoinForm(false);
     setJoinCode("");
@@ -205,13 +244,18 @@ const MultiplayerLobby = () => {
 export default MultiplayerLobby;
 
 // Styled Components
+
+/** Props for OptionCard component */
 interface OptionCardProps {
   disabled?: boolean;
 }
+
+/** Props for Button component */
 interface ButtonProps {
   $secondary?: boolean;
 }
 
+/** Props for Input component */
 interface InputProps {
   isInvalid?: boolean;
 }

--- a/src/pages/MultiplayerLobby.tsx
+++ b/src/pages/MultiplayerLobby.tsx
@@ -3,69 +3,65 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 import { createRoom, joinRoom, generateRoomCode, getRoom } from "../utils/roomsFirestore";
+import { useGameSession } from "../store/gameSession"; 
 
+// List of Eurovision Song Contest winners for random name assignment
 const ESC_WINNERS = [
   "Loreen 🇸🇪", "Måneskin 🇮🇹", "Conchita Wurst 🕊️", "Alexander Rybak 🎻", "ABBA 🇸🇪", "Duncan Laurence 🎹", "Netta 🐔", "Dana International 🏳️‍🌈", "Céline Dion 🇨🇭", "Johnny Logan 🇮🇪", "Ruslana 🔥", "Lena 🇩🇪", "Lordi 👹", "Eleni Foureira 🔥", "Helena Paparizou 🇬🇷", "Marija Šerifović 🌈", "Emmelie de Forest 🎤", "Verka Serduchka 🌟", "Mahmood 🇮🇹", "Käärijä 💚", "Chanel 💃", "Barbara Pravi 🇫🇷", "Cornelia Jakobs 🌌", "Salvador Sobral 🕊️", "Noa Kirel 🦄", "Teya & Salena 🧪", "KEiiNO 🐺", "Benjamin Ingrosso 💫", "Subwoolfer 🚀", "Daði Freyr 🧔", "Rosa Linn 🧵", "Marco Mengoni 🎙️", "Gjon's Tears 😢", "Alessandra 👑", "Sam Ryder 🚀", "Go_A 🌿", "S10 🌧️", "Sergey Lazarev 💎", "Stefania 🐎", "Il Volo 🎶"
 ];
 
-// Helper function to find a unique player name
 const getUniquePlayerName = async (roomCode: string, namesList: string[]): Promise<string> => {
-  // Get the current room data
   const room = await getRoom(roomCode);
 
   if (!room) {
-    // If room doesn't exist, any name is fine
     return namesList[Math.floor(Math.random() * namesList.length)];
   }
 
-  // Get all names currently in use
   const usedNames = room.players.map(player => player.name);
-
-  // Filter out names that are already used
   const availableNames = namesList.filter(name => !usedNames.includes(name));
 
   if (availableNames.length === 0) {
-    // If all names are taken, add a number suffix to a random name
     const baseName = namesList[Math.floor(Math.random() * namesList.length)];
     return `${baseName} #${Math.floor(Math.random() * 1000)}`;
   }
 
-  // Return a random available name
   return availableNames[Math.floor(Math.random() * availableNames.length)];
 };
 
 const MultiplayerLobby = () => {
-  const [_gameCode, setGameCode] = useState<string | null>(null); // Renamed to _gameCode as it's not used directly
+  const setMultiplayer = useGameSession((state) => state.setMultiplayerMode);
+  const setPlayerIdentity = useGameSession((state) => state.setPlayerIdentity);
+  const setRoomInfo = useGameSession((state) => state.setRoomInfo);
+  
+  // Local component state
   const [joinCode, setJoinCode] = useState("");
   const [loading, setLoading] = useState(false);
-  const [showJoinForm, setShowJoinForm] = useState(false); // Added missing state variable
+  const [showJoinForm, setShowJoinForm] = useState(false);
   const [showCreateOptions, setShowCreateOptions] = useState(false);
   const [attempted, setAttempted] = useState(false);
   const navigate = useNavigate();
 
-  // Function to create game with host as observer
   const createGame = async (hostIsObserver: boolean) => {
     setLoading(true);
     try {
-      // Generate a unique ID for the host
       const hostId = uuidv4();
       const hostName = "👑 HOST 👑";
-
-      // Generate a room code
       const newGameCode = generateRoomCode();
 
-      // Create the room in Firestore
       await createRoom(newGameCode, hostId, hostName, hostIsObserver);
 
-      // Save user info in local storage
+      // Write to Zustand
+      setMultiplayer(true);
+      setPlayerIdentity(hostId, hostName, true);
+      setRoomInfo(newGameCode, hostIsObserver);
+
+      // Keep old localStorage for backward compatibility (temporary)
       localStorage.setItem("playerId", hostId);
       localStorage.setItem("playerName", hostName);
       localStorage.setItem("gameCode", newGameCode);
       localStorage.setItem("isHost", "true");
       localStorage.setItem("hostIsObserver", String(hostIsObserver));
 
-      // Update state and navigate
-      setGameCode(newGameCode);
       navigate("/lobby");
     } catch (error) {
       console.error("Error creating game:", error);
@@ -75,12 +71,10 @@ const MultiplayerLobby = () => {
     }
   };
 
-  // Function to handle showing create game options
   const handleShowCreateOptions = () => {
     setShowCreateOptions(true);
   };
 
-  // Function to join an existing game
   const joinGame = async () => {
     setAttempted(true);
 
@@ -93,36 +87,36 @@ const MultiplayerLobby = () => {
 
     setLoading(true);
     try {
-      // Generate a unique ID for the player
       const playerId = uuidv4();
-
-      // Get a unique name for the player
-      let randomName = await getUniquePlayerName(joinCode.toUpperCase(), ESC_WINNERS);
-
-      // Join the room in Firestore
+      const randomName = await getUniquePlayerName(joinCode.toUpperCase(), ESC_WINNERS);
       const joined = await joinRoom(joinCode.toUpperCase(), playerId, randomName);
 
       if (joined) {
-        // Save user info in local storage
+        // Write to Zustand
+        setMultiplayer(true);
+        setPlayerIdentity(playerId, randomName, false);
+        setRoomInfo(joinCode.toUpperCase(), false);
+
+        // Keep old localStorage for backward compatibility (temporary)
         localStorage.setItem("playerId", playerId);
         localStorage.setItem("playerName", randomName);
         localStorage.setItem("gameCode", joinCode.toUpperCase());
         localStorage.setItem("isHost", "false");
 
-        // Navigate to lobby
         navigate("/lobby");
       } else {
         alert("Game not found or already started!");
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error joining game:", error);
       
-      // Specific error messages
-      if (error.message.includes('Security rules')) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      
+      if (errorMessage.includes('Security rules')) {
         alert("Unable to join game due to security restrictions. Please try again.");
-      } else if (error.message.includes('not found')) {
+      } else if (errorMessage.includes('not found')) {
         alert("Game not found! Please check the code and try again.");
-      } else if (error.message.includes('already started')) {
+      } else if (errorMessage.includes('already started')) {
         alert("This game has already started!");
       } else {
         alert("Failed to join game. Please try again.");
@@ -136,7 +130,6 @@ const MultiplayerLobby = () => {
     setShowJoinForm(true);
   };
 
-  // Added function to go back to options
   const handleBackToOptions = () => {
     setShowJoinForm(false);
     setJoinCode("");
@@ -176,7 +169,7 @@ const MultiplayerLobby = () => {
             {loading && <LoadingText>Creating...</LoadingText>}
           </OptionCard>
 
-          <Button onClick={() => setShowCreateOptions(false)} disabled={loading} secondary style={{ marginTop: '1rem' }}>
+          <Button onClick={() => setShowCreateOptions(false)} disabled={loading} $secondary style={{ marginTop: '1rem' }}>
             Back
           </Button>
         </OptionsContainer>
@@ -196,7 +189,7 @@ const MultiplayerLobby = () => {
           />
           {attempted && (!joinCode || joinCode.length < 4 || !/^[A-Z]{4}$/.test(joinCode)) && <InputHelperText>Please enter 4 letters.</InputHelperText>}
           <ButtonGroup>
-            <Button onClick={handleBackToOptions} disabled={loading} secondary>
+            <Button onClick={handleBackToOptions} disabled={loading} $secondary>
               Back
             </Button>
             <Button onClick={joinGame} disabled={loading}>
@@ -216,7 +209,7 @@ interface OptionCardProps {
   disabled?: boolean;
 }
 interface ButtonProps {
-  secondary?: boolean;
+  $secondary?: boolean;
 }
 
 interface InputProps {
@@ -350,17 +343,17 @@ const ButtonGroup = styled.div`
 
 const Button = styled.button<ButtonProps>`
     padding: 0.75rem 1.25rem; /* 12px 20px */
-    background: ${({ secondary, theme }) => secondary ? theme.colors.darkpurple : theme.colors.purple};
+    background: ${({ $secondary, theme }) => $secondary ? theme.colors.darkpurple : theme.colors.purple};
     color: ${({ theme }) => theme.colors.white};
     font-size: 1rem;
     font-weight: bold;
     border: none;
     cursor: pointer;
-    flex: ${props => props.secondary ? '0.4' : '0.6'};
+    flex: ${props => props.$secondary ? '0.4' : '0.6'};
     transition: all 0.2s ease;
 
     &:hover {
-      background: ${({ secondary, theme }) => secondary ? theme.colors.purple : theme.colors.darkpurple};
+       background: ${({ $secondary, theme }) => $secondary ? theme.colors.purple : theme.colors.darkpurple};
     }
     
     &:disabled {

--- a/src/pages/MultiplayerLobby.tsx
+++ b/src/pages/MultiplayerLobby.tsx
@@ -125,12 +125,11 @@ const MultiplayerLobby = () => {
       const joined = await joinRoom(joinCode.toUpperCase(), playerId, randomName);
 
       if (joined) {
-        // Write to Zustand
         setMultiplayer(true);
         setPlayerIdentity(playerId, randomName, false);
         setRoomInfo(joinCode.toUpperCase(), false);
 
-        // Keep old localStorage for backward compatibility (temporary)
+        // Keep old localStorage for backward compatibility (temporary) TODO: remove later
         localStorage.setItem("playerId", playerId);
         localStorage.setItem("playerName", randomName);
         localStorage.setItem("gameCode", joinCode.toUpperCase());

--- a/src/store/gameSession.ts
+++ b/src/store/gameSession.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface GameSessionState {
+// Mode and player info
+  isMultiplayer: boolean; 
+  playerId: string | null;
+  playerName: string | null;
+  isHost: boolean;
+  roomCode: string | null;
+  hostIsObserver: boolean;
+
+// Game state info
+  difficulty: 'easy' | 'medium' | 'hard' | null; // Changed: allow null
+  currentQuestionIndex: number;
+  score: number; 
+  isGameActive: boolean;
+
+// Actions
+  setMultiplayerMode: (isMultiplayer: boolean) => void;
+  setPlayerIdentity: (playerId: string, playerName: string, isHost: boolean) => void;
+  setRoomInfo: (roomCode: string, hostIsObserver?: boolean) => void;
+  setDifficulty: (difficulty: 'easy' | 'medium' | 'hard') => void;
+  setCurrentQuestionIndex: (index: number) => void;
+  incrementScore: (points: number) => void;
+  setScore: (score: number) => void;
+  resetGame: () => void;
+  clearSession: () => void;
+}
+
+export const useGameSession = create<GameSessionState>()(
+  persist(
+    (set) => ({
+      // Initial state
+      isMultiplayer: false,
+      playerId: null,
+      playerName: null,
+      isHost: false,
+      roomCode: null,
+      hostIsObserver: false,
+      difficulty: null,
+      currentQuestionIndex: 0,
+      score: 0,
+      isGameActive: false,
+      
+      // Actions
+      setMultiplayerMode: (isMultiplayer) => 
+        set({ isMultiplayer }),
+      
+      setPlayerIdentity: (playerId, playerName, isHost) => 
+        set({ playerId, playerName, isHost }),
+      
+      setRoomInfo: (roomCode, hostIsObserver = false) => 
+        set({ roomCode, hostIsObserver }),
+      
+      setDifficulty: (difficulty) => 
+        set({ difficulty }),
+      
+      setCurrentQuestionIndex: (index) => 
+        set({ currentQuestionIndex: index }),
+      
+      incrementScore: (points) => 
+        set((state) => ({ score: state.score + points })),
+      
+      setScore: (score) => 
+        set({ score }),
+      
+      resetGame: () => 
+        set({ 
+          currentQuestionIndex: 0, 
+          score: 0, 
+          isGameActive: false 
+        }),
+      
+      clearSession: () => 
+        set({
+          isMultiplayer: false,
+          playerId: null,
+          playerName: null,
+          isHost: false,
+          roomCode: null,
+          hostIsObserver: false,
+          difficulty: null,
+          currentQuestionIndex: 0,
+          score: 0,
+          isGameActive: false,
+        }),
+    }),
+    {
+      name: 'europarty:session',
+    }
+  )
+);
+
+// Expose store to window object in development
+declare global {
+  interface Window {
+    gameSession?: ReturnType<typeof useGameSession>;
+  }
+}
+
+if (import.meta.env.DEV) {
+  window.gameSession = useGameSession;
+  console.log('🎮 Game session store exposed to window.gameSession');
+}


### PR DESCRIPTION

**Closes:** #25 

## What
Replaces scattered game state (navigation/localStorage/sessionStorage) with a centralized Zustand store.

## Why
- State was scattered and causing bugs after refresh
- Needed single source of truth before further refactoring
- Part of Phase 1 stabilization

## Changes
- Added Zustand with persist middleware (`europarty:session`)
- Created `src/store/gameSession.ts` with full TypeScript typing
- `MultiplayerLobby` now writes to store on create/join
- Fixed styled-components `secondary` prop warning
- Cleaned up unused variables and comments

## Testing
- [x] Create room → state persists
- [x] Join room → state persists
- [x] Refresh → state restored
- [x] No TypeScript errors

## Notes
- Backward compatibility maintained during migration
- CHANGELOG.md updated

**Labels:** phase1, state, refactor, typescript  
**Estimate:** 2-4h