### PR TITLE
chore: local env/emulator setup and zustand typing fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env.local (or .env) and fill in your Firebase values.
+# Do NOT commit secrets to the repository. Add `.env.local` to .gitignore.
+
+# Required Firebase config (Vite only exposes keys with VITE_ prefix)
+VITE_FIREBASE_API_KEY=your_api_key_here
+VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=1234567890
+VITE_FIREBASE_APP_ID=1:1234567890:web:abcdef123456
+VITE_FIREBASE_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Optional: use the local Firebase emulator for Firestore during development
+# Set to "true" to connect to the emulator (default: false)
+VITE_USE_FIREBASE_EMULATOR=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 ## [Unreleased]
 ### Added
 - Added host observer mode allowing quiz hosts to monitor players without participating (13 May 2025)
+- Added initial Zustand client store sketch for session and multiplayer state management (2026-05-16)
+- Added GitHub Actions CI workflow to run build and lint on PRs (2026-05-16)
+### Changed
+- Updated Home navigation: Single-player button now routes to `/select-difficulty` (2026-05-16)
+### Updated
+- Expanded repository Copilot instructions to document tech stack, env vars, CI guidance, and dev recommendations (2026-05-16)
 - Added dedicated HostObserverView component for better separation of concerns (14 May 2025)
 - Added player readiness tracking at mid-quiz scoreboard to ensure all participants are ready before continuing (14 May 2025)
 
@@ -23,6 +29,7 @@
 - Standardized button styling across components for better UI consistency (14 May 2025)
 
 ### Fixed
+- Fixed Zustand setup by adding the missing dependency and updating `useGameStore` typings/imports for strict TypeScript builds (2026-05-16)
 - Fixed scoreboard not updating dynamically for observing hosts when participants answer questions (13 May 2025)
 - Fixed quiz timer issue with duplicate cleanup functions causing timer malfunction when reaching zero (13 May 2025)
 - Removed unused interface definition in HostObserverView component (14 May 2025)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ npm run dev
 ```
 Open your browser and follow the link provided in your terminal.
 
+### 🔑 Environment variables
+
+Copy `.env.example` to `.env.local` and fill in your Firebase project values. Vite exposes env vars that start with `VITE_`, and this project expects the following keys:
+
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_FIREBASE_MEASUREMENT_ID` (optional)
+
+To use the local Firestore emulator during development, set `VITE_USE_FIREBASE_EMULATOR=true` in your `.env.local` and run the Firebase emulator suite. Do not commit `.env.local` to version control.
+
+Note: the Firestore emulator requires a working Java runtime on your system. If you see the error "Unable to locate a Java Runtime" install a JDK (e.g., from https://adoptium.net/) and ensure `java -version` works. Also authenticate the Firebase CLI with `firebase login` before starting emulators.
+
+Quick emulator start:
+```
+npm run emulators
+```
+
 ---
 
 ### 🌐 Live Demo

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,12 @@
+{
+  "emulators": {
+    "firestore": {
+      "host": "127.0.0.1",
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.5",
         "styled-components": "^6.1.15",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -2147,7 +2148,7 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4926,6 +4927,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "emulators": "firebase emulators:start --only firestore",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
@@ -20,7 +21,8 @@
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.5",
     "styled-components": "^6.1.15",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+
+type Player = {
+  id: string;
+  name: string;
+  score?: number;
+  isObserver?: boolean;
+};
+
+type RoomState = {
+  code?: string;
+  difficulty?: string;
+  started?: boolean;
+  players: Player[];
+};
+
+type GameState = {
+  playerId?: string;
+  playerName?: string;
+  isHost?: boolean;
+  room: RoomState;
+  setPlayer: (id: string, name: string, isHost?: boolean) => void;
+  setRoom: (room: Partial<RoomState>) => void;
+  updatePlayerScore: (id: string, delta: number) => void;
+  reset: () => void;
+};
+
+export const useGameStore = create<GameState>((set) => ({
+  playerId: undefined,
+  playerName: undefined,
+  isHost: false,
+  room: { players: [] },
+  setPlayer: (id, name, isHost = false) => {
+    set({ playerId: id, playerName: name, isHost });
+    try {
+      sessionStorage.setItem('playerId', id);
+      sessionStorage.setItem('playerName', name);
+      sessionStorage.setItem('isHost', JSON.stringify(isHost));
+    } catch {
+      // ignore sessionStorage errors
+    }
+  },
+  setRoom: (room: Partial<RoomState>) => set((state: GameState) => ({ room: { ...state.room, ...room } })),
+  updatePlayerScore: (id: string, delta: number) =>
+    set((state) => ({
+      room: {
+        ...state.room,
+        players: state.room.players.map((p: Player) => (p.id === id ? { ...p, score: (p.score || 0) + delta } : p)),
+      },
+    })),
+  reset: () => {
+    set({ playerId: undefined, playerName: undefined, isHost: false, room: { players: [] } });
+    try {
+      sessionStorage.removeItem('playerId');
+      sessionStorage.removeItem('playerName');
+      sessionStorage.removeItem('isHost');
+      sessionStorage.removeItem('multiplayerGame');
+    } catch {}
+  },
+}));
+
+// Optional: hydrate from sessionStorage on load
+try {
+  const playerId = sessionStorage.getItem('playerId');
+  const playerName = sessionStorage.getItem('playerName');
+  const isHost = sessionStorage.getItem('isHost');
+  if (playerId && playerName) {
+    useGameStore.getState().setPlayer(playerId, playerName, JSON.parse(isHost || 'false'));
+  }
+} catch {
+  // ignore
+}
+
+export default useGameStore;


### PR DESCRIPTION
## Summary
- add `.env.example` with required Firebase `VITE_*` keys
- add `firebase.json` for local Firestore emulator config
- document env/emulator setup in README
- add missing `zustand` dependency and strict typings in `src/store/useGameStore.ts`

## Validation
- `npm run build` passes locally

## Notes
- local `.env.local` remains untracked and should contain project-specific secrets.